### PR TITLE
add refresh button to qt window

### DIFF
--- a/source/node-lib-qt-rss/RssFeed.cpp
+++ b/source/node-lib-qt-rss/RssFeed.cpp
@@ -1,5 +1,7 @@
 #include "RssFeed.h"
+
 #include <iostream>
+#include <QGuiApplication>
 #include "node_lib.h"
 
 RssFeed* RssFeed::instance = nullptr;
@@ -31,7 +33,7 @@ void RssFeed::redrawGUI(const v8::FunctionCallbackInfo<v8::Value>& args) {
 
 void RssFeed::refreshFeed() {
     node::lib::Evaluate("emitRequest()");
-    while (node::lib::ProcessEvents()){}
+    node::lib::RunEventLoop([](){ QGuiApplication::processEvents(); });
 }
 
 void RssFeed::cppLog(const v8::FunctionCallbackInfo<v8::Value>& args){

--- a/source/node-lib-qt-rss/RssFeed.cpp
+++ b/source/node-lib-qt-rss/RssFeed.cpp
@@ -1,5 +1,6 @@
 #include "RssFeed.h"
 #include <iostream>
+#include "node_lib.h"
 
 RssFeed* RssFeed::instance = nullptr;
 
@@ -26,6 +27,11 @@ void RssFeed::clearFeed(const v8::FunctionCallbackInfo<v8::Value>& args) {
 
 void RssFeed::redrawGUI(const v8::FunctionCallbackInfo<v8::Value>& args) {
     emit getInstance().entriesChanged();
+}
+
+void RssFeed::refreshFeed() {
+    node::lib::Evaluate("emitRequest()");
+    while (node::lib::ProcessEvents()){}
 }
 
 void RssFeed::cppLog(const v8::FunctionCallbackInfo<v8::Value>& args){

--- a/source/node-lib-qt-rss/RssFeed.h
+++ b/source/node-lib-qt-rss/RssFeed.h
@@ -19,6 +19,7 @@ public:
     static void cppLog(const v8::FunctionCallbackInfo<v8::Value>& args);
     static RssFeed& getInstance();
     static void redrawGUI(const v8::FunctionCallbackInfo<v8::Value>& args);
+    Q_INVOKABLE static void refreshFeed();
 
 private:
     static RssFeed* instance;

--- a/source/node-lib-qt-rss/main.cpp
+++ b/source/node-lib-qt-rss/main.cpp
@@ -34,7 +34,12 @@ int main(int argc, char* argv[]) {
         return -1;
     }
 
-    QObject::connect(&engine, &QQmlEngine::quit, [](){ node::lib::StopEventLoop(); });
+    QObject::connect(&engine,
+            &QQmlEngine::quit,
+            [](){
+                node::lib::StopEventLoop();
+                node::lib::Deinitialize();
+            });
 
     node::lib::Initialize();
     node::lib::RegisterModule("cpp-demo-module", {
@@ -43,6 +48,6 @@ int main(int argc, char* argv[]) {
                                 {"redrawGUI", RssFeed::redrawGUI},
                               }, "cppDemoModule");
     node::lib::Run(argv[1]);
-    node::lib::RunEventLoop([](){ QCoreApplication::processEvents(); });
-    node::lib::Deinitialize();
+    RssFeed::refreshFeed();
+    app.exec();
 }

--- a/source/node-lib-qt-rss/main.cpp
+++ b/source/node-lib-qt-rss/main.cpp
@@ -34,13 +34,6 @@ int main(int argc, char* argv[]) {
         return -1;
     }
 
-    QObject::connect(&engine,
-            &QQmlEngine::quit,
-            [](){
-                node::lib::StopEventLoop();
-                node::lib::Deinitialize();
-            });
-
     node::lib::Initialize();
     node::lib::RegisterModule("cpp-demo-module", {
                                 {"cppLog", RssFeed::cppLog},
@@ -50,4 +43,5 @@ int main(int argc, char* argv[]) {
     node::lib::Run(argv[1]);
     RssFeed::refreshFeed();
     app.exec();
+    node::lib::Deinitialize();
 }

--- a/source/node-lib-qt-rss/main.qml
+++ b/source/node-lib-qt-rss/main.qml
@@ -9,7 +9,13 @@ ApplicationWindow {
     title: qsTr("RSS Feed Viewer using Node.js")
     onClosing: Qt.quit()
 
+
     ListView {
+        header: 
+            Button {
+                text: "Refresh"
+                onClicked: rssFeed.refreshFeed()
+            }
         anchors.fill: parent
         model: rssFeed.entries
 

--- a/source/node-lib-qt-rss/rss_feed.js
+++ b/source/node-lib-qt-rss/rss_feed.js
@@ -41,8 +41,5 @@ var emitRequest = function () {
 
   feedparser.on('end', function (){
     cppDemoModule.redrawGUI();
-    setTimeout(emitRequest, 3000);
   });
 }
-
-emitRequest();


### PR DESCRIPTION
This PR moves the control away from a permanently running, self-refreshing node-mainloop having control over Qt, over to a permanently running Qt eventloop that sometimes wakes up nodejs to refresh the feed.

I am not sure if we should maybe move this version into a new directory, as it showcases the use case "we have a big main framework and just want to use node occasionally for a small subset of tasks", instead of "we just want to be woken up by node every now and then"

closes issue #28 