### PR TITLE
Refactor Qt apps

### DIFF
--- a/data/node-lib-qt-rss.js
+++ b/data/node-lib-qt-rss.js
@@ -30,7 +30,7 @@ var emitRequest = function () {
     var stream = this; // `this` is `feedparser`, which is a stream
     var item = stream.read();
 
-    if (item) {
+    if (item && item['title']) {
       var itemString = item['title'] + '\n' + item['description'];
       cppQtGui.addFeedItem( { item: itemString } );
     }

--- a/data/node-lib-qt-rss.js
+++ b/data/node-lib-qt-rss.js
@@ -7,7 +7,7 @@ var emitRequest = function () {
   var req = request('http://feeds.bbci.co.uk/news/world/rss.xml')
 
   req.on('error', function (error) {
-    // handle any request errors
+    // catch all request errors but don't handle them in this demo
   });
 
   req.on('response', function (res) {
@@ -17,29 +17,26 @@ var emitRequest = function () {
       this.emit('error', new Error('Bad status code'));
     }
     else {
-      cppDemoModule.clearFeed();
+      cppQtGui.clearFeed();
       stream.pipe(feedparser);
     }
   });
  
   feedparser.on('error', function (error) {
-    // catch all parser errors but don't handle them
+    // catch all parser errors but don't handle them in this demo
   });
   
   feedparser.on('readable', function () {
-    // This is where the action is!
     var stream = this; // `this` is `feedparser`, which is a stream
-    var meta = this.meta; // **NOTE** the "meta" is always available in the context of the feedparser instance
-    var item;
-  
-    var itemString = '';
-    while (item = stream.read()) {
-        itemString = itemString + item['title'] + '\n' + item['description'];
+    var item = stream.read();
+
+    if (item) {
+      var itemString = item['title'] + '\n' + item['description'];
+      cppQtGui.addFeedItem( { itemTitle: itemString } );
     }
-    cppDemoModule.cppLog({itemTitle: itemString});
   });
 
   feedparser.on('end', function (){
-    cppDemoModule.redrawGUI();
+    cppQtGui.redraw();
   });
 }

--- a/data/node-lib-qt-rss.js
+++ b/data/node-lib-qt-rss.js
@@ -3,7 +3,7 @@ var request = require('request'); // for fetching the feed
 
 var emitRequest = function () {
   console.log("Refreshing feeds...")
-  var feedparser = new FeedParser([]);  
+  var feedparser = new FeedParser([]);
   var req = request('http://feeds.bbci.co.uk/news/world/rss.xml')
 
   req.on('error', function (error) {
@@ -12,7 +12,7 @@ var emitRequest = function () {
 
   req.on('response', function (res) {
     var stream = this; // `this` is `req`, which is a stream
-  
+
     if (res.statusCode !== 200) {
       this.emit('error', new Error('Bad status code'));
     }
@@ -21,18 +21,18 @@ var emitRequest = function () {
       stream.pipe(feedparser);
     }
   });
- 
+
   feedparser.on('error', function (error) {
     // catch all parser errors but don't handle them in this demo
   });
-  
+
   feedparser.on('readable', function () {
     var stream = this; // `this` is `feedparser`, which is a stream
     var item = stream.read();
 
     if (item) {
       var itemString = item['title'] + '\n' + item['description'];
-      cppQtGui.addFeedItem( { itemTitle: itemString } );
+      cppQtGui.addFeedItem( { item: itemString } );
     }
   });
 

--- a/data/node-qt-rss.js
+++ b/data/node-qt-rss.js
@@ -40,7 +40,7 @@ var emitRequest = function () {
 
     if (item) {
       var itemString = item['title'] + '\n' + item['description'];
-      cppQtGui.addFeedItem( { itemTitle: itemString } );
+      cppQtGui.addFeedItem( { item: itemString } );
     }
   });
 

--- a/data/node-qt-rss.js
+++ b/data/node-qt-rss.js
@@ -1,4 +1,4 @@
-var cppDemoModule = process.binding('CppDemoModule');
+var cppQtGui = process.binding('cpp-qt-gui');
 
 var FeedParser = require('feedparser');
 var request = require('request'); // for fetching the feed
@@ -7,48 +7,45 @@ var killMe = function () {
     process.exit();
 }
 
-cppDemoModule.registerExitFunc(killMe);
+cppQtGui.registerExitFunc(killMe);
 
 var emitRequest = function () {
   console.log("Refreshing feeds...")
-  var feedparser = new FeedParser([]);  
+  var feedparser = new FeedParser([]);
   var req = request('http://feeds.bbci.co.uk/news/world/rss.xml')
 
   req.on('error', function (error) {
-    // handle any request errors
+    // catch all request errors but don't handle them in this demo
   });
 
   req.on('response', function (res) {
     var stream = this; // `this` is `req`, which is a stream
-  
+
     if (res.statusCode !== 200) {
       this.emit('error', new Error('Bad status code'));
     }
     else {
-      cppDemoModule.clearFeed();
+      cppQtGui.clearFeed();
       stream.pipe(feedparser);
     }
   });
- 
+
   feedparser.on('error', function (error) {
-    // catch all parser errors but don't handle them
+    // catch all parser errors but don't handle them in this demo
   });
-  
+
   feedparser.on('readable', function () {
-    // This is where the action is!
     var stream = this; // `this` is `feedparser`, which is a stream
-    var meta = this.meta; // **NOTE** the "meta" is always available in the context of the feedparser instance
-    var item;
-  
-    var itemString = '';
-    while (item = stream.read()) {
-        itemString = itemString + item['title'] + '\n' + item['description'];
+    var item = stream.read();
+
+    if (item) {
+      var itemString = item['title'] + '\n' + item['description'];
+      cppQtGui.addFeedItem( { itemTitle: itemString } );
     }
-    cppDemoModule.cppLog({itemTitle: itemString});
   });
 
   feedparser.on('end', function (){
-    cppDemoModule.redrawGUI();
+    cppQtGui.redraw();
     setTimeout(emitRequest, 3000);
   });
 }
@@ -56,7 +53,7 @@ var emitRequest = function () {
 emitRequest();
 
 function processQtEvents() {
-    cppDemoModule.processQtEvents()
+    cppQtGui.processQtEvents()
     setTimeout(processQtEvents, 20);
 }
 

--- a/data/node-qt-rss.js
+++ b/data/node-qt-rss.js
@@ -3,11 +3,7 @@ var cppQtGui = process.binding('cpp-qt-gui');
 var FeedParser = require('feedparser');
 var request = require('request'); // for fetching the feed
 
-var killMe = function () {
-    process.exit();
-}
-
-cppQtGui.registerExitFunc(killMe);
+cppQtGui.registerExitFunc(process.exit);
 
 var emitRequest = function () {
   console.log("Refreshing feeds...")

--- a/data/node-qt-rss.js
+++ b/data/node-qt-rss.js
@@ -38,7 +38,7 @@ var emitRequest = function () {
     var stream = this; // `this` is `feedparser`, which is a stream
     var item = stream.read();
 
-    if (item) {
+    if (item && item['title']) {
       var itemString = item['title'] + '\n' + item['description'];
       cppQtGui.addFeedItem( { item: itemString } );
     }

--- a/source/node-lib-qt-rss/RssFeed.cpp
+++ b/source/node-lib-qt-rss/RssFeed.cpp
@@ -7,54 +7,63 @@
 RssFeed* RssFeed::instance = nullptr;
 
 RssFeed::RssFeed(QObject* parent)
-    : QObject(parent)
+  : QObject(parent)
 {
-   
+
 }
 
 RssFeed& RssFeed::getInstance(){
-    if (instance == nullptr){
-        instance = new RssFeed();
-    }
-    return *instance;
+  if (instance == nullptr){
+    instance = new RssFeed();
+  }
+  return *instance;
 }
 
 QStringList RssFeed::getEntries() const {
-    return entries;
+  return entries;
 }
 
 void RssFeed::clearFeed(const v8::FunctionCallbackInfo<v8::Value>& args) {
-     getInstance().entries.clear();
+  getInstance().entries.clear();
 }
 
 void RssFeed::redrawGUI(const v8::FunctionCallbackInfo<v8::Value>& args) {
-    emit getInstance().entriesChanged();
+  emit getInstance().entriesChanged();
 }
 
 void RssFeed::refreshFeed() {
-    node::Evaluate("emitRequest()");
-    node::RunEventLoop([](){ QGuiApplication::processEvents(); });
+  // invoke the embedded JavaScript in order to fetch new RSS feeds:
+  node::Evaluate("emitRequest()");
+
+  // wait for the embedded JavaScript to finish its execution
+  // meanwhile, process any QT events
+  node::RunEventLoop([](){ QGuiApplication::processEvents(); });
 }
 
-void RssFeed::cppLog(const v8::FunctionCallbackInfo<v8::Value>& args){
-    v8::Isolate* isolate = args.GetIsolate();
-    if (args.Length() < 1 || !args[0]->IsObject()) {
-        isolate->ThrowException(v8::Exception::TypeError(
-        v8::String::NewFromUtf8(isolate, "Error: One object expected")));
-        return;
-    }
+void RssFeed::addFeedItem(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  // check, whether this method was called as expected
+  // therefore, we need to make sure, that the first argument exists
+  // and that it is an object
+  v8::Isolate* isolate = args.GetIsolate();
+  if (args.Length() < 1 || !args[0]->IsObject()) {
+    isolate->ThrowException(v8::Exception::TypeError(
+                              v8::String::NewFromUtf8(isolate, "Error: One object expected")));
+    return;
+  }
 
-    v8::Local<v8::Context> context = isolate->GetCurrentContext();
-    v8::Local<v8::Object> obj = args[0]->ToObject(context).ToLocalChecked();
-    v8::Local<v8::Array> props = obj->GetOwnPropertyNames(context).ToLocalChecked();
-    //getInstance().entries.clear();
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
+  v8::Local<v8::Object> obj = args[0]->ToObject(context).ToLocalChecked();
 
+  // we want to get all properties of our input object:
+  v8::Local<v8::Array> props = obj->GetOwnPropertyNames(context).ToLocalChecked();
 
-    for (int i = 0, l = props->Length(); i < l; i++) {
-        v8::Local<v8::Value> localKey = props->Get(i);
-        v8::Local<v8::Value> localVal = obj->Get(context, localKey).ToLocalChecked();
-        std::string key = *v8::String::Utf8Value(localKey);
-        std::string val = *v8::String::Utf8Value(localVal);
-        getInstance().entries << QString::fromStdString(val);
-    }
+  for (int i = 0, l = props->Length(); i < l; i++) {
+    v8::Local<v8::Value> localKey = props->Get(i);
+    v8::Local<v8::Value> localVal = obj->Get(context, localKey).ToLocalChecked();
+    std::string key = *v8::String::Utf8Value(localKey);
+    std::string val = *v8::String::Utf8Value(localVal);
+
+    // append the RSS feed body to the list of RSS feeds:
+    getInstance().entries << QString::fromStdString(val);
+  }
 }

--- a/source/node-lib-qt-rss/RssFeed.h
+++ b/source/node-lib-qt-rss/RssFeed.h
@@ -5,35 +5,79 @@
 #include "node.h"
 
 /**
- * @brief The RssFeed class retrieves an RSS feed from the Internet and provides its entries.
+ * @brief The RssFeed class retrieves an RSS feed from the Internet and
+ * provides its entries.
  */
 class RssFeed : public QObject {
 
-    Q_OBJECT
+  Q_OBJECT
 
-    Q_PROPERTY(QStringList entries READ getEntries NOTIFY entriesChanged)
-
-public:
-    explicit RssFeed(QObject* parent=nullptr);
-    static void clearFeed(const v8::FunctionCallbackInfo<v8::Value>& args);
-    static void cppLog(const v8::FunctionCallbackInfo<v8::Value>& args);
-    static RssFeed& getInstance();
-    static void redrawGUI(const v8::FunctionCallbackInfo<v8::Value>& args);
-    Q_INVOKABLE static void refreshFeed();
+  Q_PROPERTY(QStringList entries READ getEntries NOTIFY entriesChanged)
 
 private:
-    static RssFeed* instance;
-    QStringList entries;
+  /**
+   * @brief Creates a new RssFeed with a given QObject as its parent.
+   *
+   * @param parent The parent object.
+   */
+  explicit RssFeed(QObject* parent=nullptr);
+
+public:
+  /**
+   * @brief Returns the singleton instance for this class.
+   *
+   * @return The singlton instance for this class.
+   */
+  static RssFeed& getInstance();
+
+  /**
+   * @brief This method is called from the embedded JavaScript.
+   * It is used for deleting all items from this RSS feed.
+   *
+   * @param args The arguments passed from the embedded JavaScript.
+   * Hint: This method does not expect any arguments.
+   */
+  static void clearFeed(const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  /**
+   * @brief This method is called from the embedded JavaScript.
+   * It is used to add an entry to this RSS feed.
+   *
+   * @param args The arguments passed from the embedded JavaScript.
+   * Hint: This method expects an object, which contains the RSS feed item.
+   */
+  static void addFeedItem(const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  /**
+   * @brief This method is called from the embedded JavaScript.
+   * It is used to refresh the GUI, after all retrieved feed items have been
+   * appended.
+   *
+   * @param args The arguments passed from the embedded JavaScript.
+   * Hint: This method does not expect any arguments.
+   */
+  static void redrawGUI(const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  /**
+   * @brief This method updates the feed by calling a JS function
+   * and running the Node.js main loop until the whole feed was received.
+   */
+  Q_INVOKABLE static void refreshFeed();
+
+private:
+  static RssFeed* instance;   /*!< The singleton instance for this class. */
+  QStringList entries;        /*!< The list of RSS feeds to display. */
 
 signals:
-    void entriesChanged();
+  void entriesChanged();      /*!< Emitted after entries were added or removed. */
 
 public slots:
-    /**
-     * @brief getEntries returns the entries of the RSS feed
-     * @return a list of text entries
-     */
-    QStringList getEntries() const;
+  /**
+   * @brief getEntries returns the entries of the RSS feed
+   *
+   * @return a list of text entries
+   */
+  QStringList getEntries() const;
 };
 
 #endif // RSSFEED_H

--- a/source/node-lib-qt-rss/main.cpp
+++ b/source/node-lib-qt-rss/main.cpp
@@ -6,7 +6,6 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
-#include <QTimer>
 
 #include <cpplocate/cpplocate.h>
 
@@ -20,7 +19,7 @@ int main(int argc, char* argv[]) {
   const std::string js_file = "data/node-lib-qt-rss.js";
   const std::string data_path = cpplocate::locatePath(js_file);
   if (data_path.empty()) {
-    std::cerr << "Could not find data path." << std::endl;
+    qWarning() << "Could not find data path.";
     return 1;
   }
   const std::string js_path = data_path + "/" + js_file;
@@ -37,7 +36,7 @@ int main(int argc, char* argv[]) {
   engine.load(QUrl(QLatin1String("qrc:/main.qml")));
   if (engine.rootObjects().isEmpty()) {
     qWarning() << "Error while loading QML file";
-    return -1;
+    return 1;
   }
 
   // Initialize Node.js engine:

--- a/source/node-qt-rss/RssFeed.cpp
+++ b/source/node-qt-rss/RssFeed.cpp
@@ -31,15 +31,6 @@ void RssFeed::redrawGUI(const v8::FunctionCallbackInfo<v8::Value>& args) {
   emit getInstance().entriesChanged();
 }
 
-void RssFeed::refreshFeed() {
-  // invoke the embedded JavaScript in order to fetch new RSS feeds:
-  node::Evaluate("emitRequest()");
-
-  // wait for the embedded JavaScript to finish its execution
-  // meanwhile, process any QT events
-  node::RunEventLoop([](){ QGuiApplication::processEvents(); });
-}
-
 void RssFeed::addFeedItem(const v8::FunctionCallbackInfo<v8::Value>& args) {
   // check, whether this method was called as expected
   // therefore, we need to make sure, that the first argument exists

--- a/source/node-qt-rss/RssFeed.cpp
+++ b/source/node-qt-rss/RssFeed.cpp
@@ -1,52 +1,69 @@
 #include "RssFeed.h"
+
 #include <iostream>
+#include <QGuiApplication>
+#include "node_lib.h"
 
 RssFeed* RssFeed::instance = nullptr;
 
 RssFeed::RssFeed(QObject* parent)
-    : QObject(parent)
+  : QObject(parent)
 {
-   
+
 }
 
 RssFeed& RssFeed::getInstance(){
-    if (instance == nullptr){
-        instance = new RssFeed();
-    }
-    return *instance;
+  if (instance == nullptr){
+    instance = new RssFeed();
+  }
+  return *instance;
 }
 
 QStringList RssFeed::getEntries() const {
-    return entries;
+  return entries;
 }
 
 void RssFeed::clearFeed(const v8::FunctionCallbackInfo<v8::Value>& args) {
-     getInstance().entries.clear();
+  getInstance().entries.clear();
 }
 
 void RssFeed::redrawGUI(const v8::FunctionCallbackInfo<v8::Value>& args) {
-    emit getInstance().entriesChanged();
+  emit getInstance().entriesChanged();
 }
 
-void RssFeed::cppLog(const v8::FunctionCallbackInfo<v8::Value>& args){
-    v8::Isolate* isolate = args.GetIsolate();
-    if(args.Length() < 1 || !args[0]->IsObject()) {
-        isolate->ThrowException(v8::Exception::TypeError(
-        v8::String::NewFromUtf8(isolate, "Error: One object expected")));
-        return;
-    }
+void RssFeed::refreshFeed() {
+  // invoke the embedded JavaScript in order to fetch new RSS feeds:
+  node::Evaluate("emitRequest()");
 
-    v8::Local<v8::Context> context = isolate->GetCurrentContext();
-    v8::Local<v8::Object> obj = args[0]->ToObject(context).ToLocalChecked();
-    v8::Local<v8::Array> props = obj->GetOwnPropertyNames(context).ToLocalChecked();
-    //getInstance().entries.clear();
+  // wait for the embedded JavaScript to finish its execution
+  // meanwhile, process any QT events
+  node::RunEventLoop([](){ QGuiApplication::processEvents(); });
+}
 
+void RssFeed::addFeedItem(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  // check, whether this method was called as expected
+  // therefore, we need to make sure, that the first argument exists
+  // and that it is an object
+  v8::Isolate* isolate = args.GetIsolate();
+  if (args.Length() < 1 || !args[0]->IsObject()) {
+    isolate->ThrowException(v8::Exception::TypeError(
+                              v8::String::NewFromUtf8(isolate, "Error: One object expected")));
+    return;
+  }
 
-    for(int i = 0, l = props->Length(); i < l; i++) {
-        v8::Local<v8::Value> localKey = props->Get(i);
-        v8::Local<v8::Value> localVal = obj->Get(context, localKey).ToLocalChecked();
-        std::string key = *v8::String::Utf8Value(localKey);
-        std::string val = *v8::String::Utf8Value(localVal);
-        getInstance().entries << QString::fromStdString(val);
-    }
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
+  v8::Local<v8::Object> obj = args[0]->ToObject(context).ToLocalChecked();
+
+  // we want to get all properties of our input object:
+  v8::Local<v8::Array> props = obj->GetOwnPropertyNames(context).ToLocalChecked();
+
+  for (int i = 0, l = props->Length(); i < l; i++) {
+    v8::Local<v8::Value> localKey = props->Get(i);
+    v8::Local<v8::Value> localVal = obj->Get(context, localKey).ToLocalChecked();
+    std::string key = *v8::String::Utf8Value(localKey);
+    std::string val = *v8::String::Utf8Value(localVal);
+
+    // append the RSS feed body to the list of RSS feeds:
+    getInstance().entries << QString::fromStdString(val);
+  }
 }

--- a/source/node-qt-rss/RssFeed.h
+++ b/source/node-qt-rss/RssFeed.h
@@ -5,34 +5,79 @@
 #include "node.h"
 
 /**
- * @brief The RssFeed class retrieves an RSS feed from the Internet and provides its entries.
+ * @brief The RssFeed class retrieves an RSS feed from the Internet and
+ * provides its entries.
  */
 class RssFeed : public QObject {
 
-    Q_OBJECT
+  Q_OBJECT
 
-    Q_PROPERTY(QStringList entries READ getEntries NOTIFY entriesChanged)
-
-public:
-    explicit RssFeed(QObject* parent=nullptr);
-    static void clearFeed(const v8::FunctionCallbackInfo<v8::Value>& args);
-    static void cppLog(const v8::FunctionCallbackInfo<v8::Value>& args);
-    static RssFeed& getInstance();
-    static void redrawGUI(const v8::FunctionCallbackInfo<v8::Value>& args);
+  Q_PROPERTY(QStringList entries READ getEntries NOTIFY entriesChanged)
 
 private:
-    static RssFeed* instance;
-    QStringList entries;
+  /**
+   * @brief Creates a new RssFeed with a given QObject as its parent.
+   *
+   * @param parent The parent object.
+   */
+  explicit RssFeed(QObject* parent=nullptr);
+
+public:
+  /**
+   * @brief Returns the singleton instance for this class.
+   *
+   * @return The singlton instance for this class.
+   */
+  static RssFeed& getInstance();
+
+  /**
+   * @brief This method is called from the embedded JavaScript.
+   * It is used for deleting all items from this RSS feed.
+   *
+   * @param args The arguments passed from the embedded JavaScript.
+   * Hint: This method does not expect any arguments.
+   */
+  static void clearFeed(const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  /**
+   * @brief This method is called from the embedded JavaScript.
+   * It is used to add an entry to this RSS feed.
+   *
+   * @param args The arguments passed from the embedded JavaScript.
+   * Hint: This method expects an object, which contains the RSS feed item.
+   */
+  static void addFeedItem(const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  /**
+   * @brief This method is called from the embedded JavaScript.
+   * It is used to refresh the GUI, after all retrieved feed items have been
+   * appended.
+   *
+   * @param args The arguments passed from the embedded JavaScript.
+   * Hint: This method does not expect any arguments.
+   */
+  static void redrawGUI(const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  /**
+   * @brief This method updates the feed by calling a JS function
+   * and running the Node.js main loop until the whole feed was received.
+   */
+  Q_INVOKABLE static void refreshFeed();
+
+private:
+  static RssFeed* instance;   /*!< The singleton instance for this class. */
+  QStringList entries;        /*!< The list of RSS feeds to display. */
 
 signals:
-    void entriesChanged();
+  void entriesChanged();      /*!< Emitted after entries were added or removed. */
 
 public slots:
-    /**
-     * @brief getEntries returns the entries of the RSS feed
-     * @return a list of text entries
-     */
-    QStringList getEntries() const;
+  /**
+   * @brief getEntries returns the entries of the RSS feed
+   *
+   * @return a list of text entries
+   */
+  QStringList getEntries() const;
 };
 
 #endif // RSSFEED_H

--- a/source/node-qt-rss/RssFeed.h
+++ b/source/node-qt-rss/RssFeed.h
@@ -58,12 +58,6 @@ public:
    */
   static void redrawGUI(const v8::FunctionCallbackInfo<v8::Value>& args);
 
-  /**
-   * @brief This method updates the feed by calling a JS function
-   * and running the Node.js main loop until the whole feed was received.
-   */
-  Q_INVOKABLE static void refreshFeed();
-
 private:
   static RssFeed* instance;   /*!< The singleton instance for this class. */
   QStringList entries;        /*!< The list of RSS feeds to display. */

--- a/source/node-qt-rss/main.cpp
+++ b/source/node-qt-rss/main.cpp
@@ -7,8 +7,6 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
-#include <QtConcurrent>
-#include <QTimer>
 
 #include <cpplocate/cpplocate.h>
 
@@ -67,7 +65,7 @@ int main(int argc, char* argv[]) {
   const std::string js_file = "data/node-qt-rss.js";
   const std::string data_path = cpplocate::locatePath(js_file);
   if (data_path.empty()) {
-    std::cerr << "Could not find data path." << std::endl;
+    qWarning() << "Could not find data path.";
     return 1;
   }
   std::string js_path = data_path + "/" + js_file;
@@ -84,7 +82,7 @@ int main(int argc, char* argv[]) {
   engine.load(QUrl(QLatin1String("qrc:/main.qml")));
   if (engine.rootObjects().isEmpty()) {
     qWarning() << "Error while loading QML file";
-    return -1;
+    return 1;
   }
 
   // Create node module

--- a/source/node-qt-rss/main.cpp
+++ b/source/node-qt-rss/main.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
-#include <thread>
 #include <chrono>
 #include <cstring>
+#include <thread>
 
 #include <QDebug>
 #include <QGuiApplication>
@@ -25,98 +25,98 @@ struct AsyncData {
 AsyncData* jsExitData = nullptr;
 
 void execAsyncCall(uv_async_t* req) {
-    AsyncData* data = static_cast<AsyncData*>(req->data);
-    v8::Isolate* isolate = v8::Isolate::GetCurrent();
-    v8::HandleScope scope(isolate);
-    v8::Handle<v8::Value> argv[] = { v8::Array::New(isolate) };
-    v8::Local<v8::Function>::New(isolate, data->callback)->
-          Call(isolate->GetCurrentContext()->Global(), 1, argv);
-    data->callback.Reset();
-    delete data;
+  AsyncData* data = static_cast<AsyncData*>(req->data);
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::HandleScope scope(isolate);
+  v8::Handle<v8::Value> argv[] = { v8::Array::New(isolate) };
+  v8::Local<v8::Function>::New(isolate, data->callback)->
+      Call(isolate->GetCurrentContext()->Global(), 1, argv);
+  data->callback.Reset();
+  delete data;
 }
 
 // callback for Node.js to register the exit-function. The exit-function is supposed to get called once the Qt-GUI
 // gets closed, this function should be called on startup of node.js
 void registerExitFunc(const v8::FunctionCallbackInfo<v8::Value>& args) {
-    v8::Isolate* isolate = args.GetIsolate();
-    v8::Local<v8::Function> callback = v8::Local<v8::Function>::Cast(args[0]);
+  v8::Isolate* isolate = args.GetIsolate();
+  v8::Local<v8::Function> callback = v8::Local<v8::Function>::Cast(args[0]);
 
-    jsExitData = new AsyncData();
-    jsExitData->request.data = jsExitData;
-    jsExitData->callback.Reset(isolate, callback);
+  jsExitData = new AsyncData();
+  jsExitData->request.data = jsExitData;
+  jsExitData->callback.Reset(isolate, callback);
 
-    uv_async_init(uv_default_loop(), &jsExitData->request, execAsyncCall);
+  uv_async_init(uv_default_loop(), &jsExitData->request, execAsyncCall);
 }
 
 void processQtEvents(const v8::FunctionCallbackInfo<v8::Value>&) {
-    QCoreApplication::processEvents();
+  QCoreApplication::processEvents();
 }
 
 // exposes C++-functions in node.js-Module _rssModule (called CppDemoModule in node.js)
 // format is NODE_SET_METHOD(exports, "functionNameInJS", functionPointerInC++).
 // From what we understand, object member functions can not be exposed to node.js like this.
 void onRegisterModule(v8::Local<v8::Object> exports, v8::Local<v8::Value>, v8::Local<v8::Context>, void * /*data*/) {
-    NODE_SET_METHOD(exports, "cppLog", RssFeed::cppLog);
-    NODE_SET_METHOD(exports, "registerExitFunc", registerExitFunc);
-    NODE_SET_METHOD(exports, "clearFeed", RssFeed::clearFeed);
-    NODE_SET_METHOD(exports, "redrawGUI", RssFeed::redrawGUI);
-    NODE_SET_METHOD(exports, "processQtEvents", processQtEvents);
+  NODE_SET_METHOD(exports, "addFeedItem", RssFeed::addFeedItem);
+  NODE_SET_METHOD(exports, "registerExitFunc", registerExitFunc);
+  NODE_SET_METHOD(exports, "clearFeed", RssFeed::clearFeed);
+  NODE_SET_METHOD(exports, "redraw", RssFeed::redrawGUI);
+  NODE_SET_METHOD(exports, "processQtEvents", processQtEvents);
 }
 
 int main(int argc, char* argv[]) {
-    const std::string js_file = "data/node-qt-rss.js";
-    const std::string data_path = cpplocate::locatePath(js_file);
-    if (data_path.empty()) {
-        std::cerr << "Could not find data path." << std::endl;
-        return 1;
-    }
-    std::string js_path = data_path + "/" + js_file;
+  const std::string js_file = "data/node-qt-rss.js";
+  const std::string data_path = cpplocate::locatePath(js_file);
+  if (data_path.empty()) {
+    std::cerr << "Could not find data path." << std::endl;
+    return 1;
+  }
+  std::string js_path = data_path + "/" + js_file;
 
-    QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-    QGuiApplication app(argc, argv);
+  QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+  QGuiApplication app(argc, argv);
 
-    QQmlApplicationEngine engine;
+  QQmlApplicationEngine engine;
 
-    // to be able to access the public slots of the RssFeed instance
-    // we inject a pointer to it in the QML context:
-    engine.rootContext()->setContextProperty("rssFeed", &RssFeed::getInstance());
+  // to be able to access the public slots of the RssFeed instance
+  // we inject a pointer to it in the QML context:
+  engine.rootContext()->setContextProperty("rssFeed", &RssFeed::getInstance());
 
-    engine.load(QUrl(QLatin1String("qrc:/main.qml")));
-    if (engine.rootObjects().isEmpty()) {
-        qWarning() << "Error while loading QML file";
-        return -1;
-    }
+  engine.load(QUrl(QLatin1String("qrc:/main.qml")));
+  if (engine.rootObjects().isEmpty()) {
+    qWarning() << "Error while loading QML file";
+    return -1;
+  }
 
-    // Create node module
-    static node::node_module _rssModule =
-    {
-        NODE_MODULE_VERSION,
-        0x01,  // FIXME: before: #define NM_F_BUILTIN   0x01
-        nullptr,
-        __FILE__,
-        nullptr,
-        onRegisterModule,
-        "CppDemoModule",
-        nullptr, // nm_priv, will be given to onRegisterModule as data? i.e. "this" pointer
-        nullptr
-    };
+  // Create node module
+  static node::node_module _rssModule =
+  {
+    NODE_MODULE_VERSION,
+    0x01,  // value of private node variable NM_F_BUILTIN
+    nullptr,
+    __FILE__,
+    nullptr,
+    onRegisterModule,
+    "cpp-qt-gui",
+    nullptr, // nm_priv, will be given to onRegisterModule as data? i.e. "this" pointer
+    nullptr
+  };
 
-    // Register module
-    node_module_register(&_rssModule);
+  // Register module
+  node_module_register(&_rssModule);
 
-    QObject::connect(&engine, &QQmlEngine::quit, [](){ uv_async_send(&jsExitData->request); });
+  QObject::connect(&engine, &QQmlEngine::quit, [](){ uv_async_send(&jsExitData->request); });
 
-    const size_t argv0_len = std::strlen(argv[0]) + 1;
-    const size_t argv1_len = js_path.size() + 1;
-    const size_t total_size = argv0_len + argv1_len;
+  const size_t argv0_len = std::strlen(argv[0]) + 1;
+  const size_t argv1_len = js_path.size() + 1;
+  const size_t total_size = argv0_len + argv1_len;
 
-    char* node_arg_string = new char[total_size]();
-    std::strcpy(&node_arg_string[0], argv[0]);
-    std::copy(js_path.begin(), js_path.end(), &node_arg_string[argv0_len]);
+  char* node_arg_string = new char[total_size]();
+  std::strcpy(&node_arg_string[0], argv[0]);
+  std::copy(js_path.begin(), js_path.end(), &node_arg_string[argv0_len]);
 
-    char* node_argv[] = {&node_arg_string[0], &node_arg_string[argv0_len]};
+  char* node_argv[] = {&node_arg_string[0], &node_arg_string[argv0_len]};
 
-    node::Start(2, node_argv);
+  node::Start(2, node_argv);
 
-    delete[] node_arg_string;
+  delete[] node_arg_string;
 }


### PR DESCRIPTION
Tidied up everything, renamed variables, made code style a bit more like in Node (indent with 2 spaces), added comments from Usage Documentation and removed BS from JS ;-)

RssFeed.h/.cpp are almost the same for both, but I kept them twice to have the apps self contained in their directories.