### PR TITLE
cpplocate::locatePath signature no longer has optional parameters

### DIFF
--- a/source/node-lib-cli/main.cpp
+++ b/source/node-lib-cli/main.cpp
@@ -12,7 +12,7 @@ void cppFunctionExposedToJs(const v8::FunctionCallbackInfo<v8::Value>& args) {
 int main(int argc, char* argv[]) {
   // Locate the JavaScript file we want to load:
   const std::string js_file = "data/node-lib-cli.js";
-  const std::string data_path = cpplocate::locatePath(js_file);
+  const std::string data_path = cpplocate::locatePath(js_file, "", NULL);
   if (data_path.empty()) {
     std::cerr << "[C++] Could not find data path." << std::endl;
     return 1;

--- a/source/node-lib-cli/main.cpp
+++ b/source/node-lib-cli/main.cpp
@@ -12,7 +12,7 @@ void cppFunctionExposedToJs(const v8::FunctionCallbackInfo<v8::Value>& args) {
 int main(int argc, char* argv[]) {
   // Locate the JavaScript file we want to load:
   const std::string js_file = "data/node-lib-cli.js";
-  const std::string data_path = cpplocate::locatePath(js_file, "", NULL);
+  const std::string data_path = cpplocate::locatePath(js_file, "", nullptr);
   if (data_path.empty()) {
     std::cerr << "[C++] Could not find data path." << std::endl;
     return 1;

--- a/source/node-lib-qt-rss/main.cpp
+++ b/source/node-lib-qt-rss/main.cpp
@@ -17,7 +17,7 @@
 int main(int argc, char* argv[]) {
   // Locate the JavaScript file we want to load:
   const std::string js_file = "data/node-lib-qt-rss.js";
-  const std::string data_path = cpplocate::locatePath(js_file);
+  const std::string data_path = cpplocate::locatePath(js_file, "", NULL);
   if (data_path.empty()) {
     qWarning() << "Could not find data path.";
     return 1;

--- a/source/node-lib-qt-rss/main.cpp
+++ b/source/node-lib-qt-rss/main.cpp
@@ -17,7 +17,7 @@
 int main(int argc, char* argv[]) {
   // Locate the JavaScript file we want to load:
   const std::string js_file = "data/node-lib-qt-rss.js";
-  const std::string data_path = cpplocate::locatePath(js_file, "", NULL);
+  const std::string data_path = cpplocate::locatePath(js_file, "", nullptr);
   if (data_path.empty()) {
     qWarning() << "Could not find data path.";
     return 1;

--- a/source/node-qt-rss/main.cpp
+++ b/source/node-qt-rss/main.cpp
@@ -64,7 +64,7 @@ void onRegisterModule(v8::Local<v8::Object> exports, v8::Local<v8::Value>, v8::L
 int main(int argc, char* argv[]) {
   // Locate the JavaScript file we want to load:
   const std::string js_file = "data/node-qt-rss.js";
-  const std::string data_path = cpplocate::locatePath(js_file, "", NULL);
+  const std::string data_path = cpplocate::locatePath(js_file, "", nullptr);
   if (data_path.empty()) {
     qWarning() << "Could not find data path.";
     return 1;

--- a/source/node-qt-rss/main.cpp
+++ b/source/node-qt-rss/main.cpp
@@ -64,7 +64,7 @@ void onRegisterModule(v8::Local<v8::Object> exports, v8::Local<v8::Value>, v8::L
 int main(int argc, char* argv[]) {
   // Locate the JavaScript file we want to load:
   const std::string js_file = "data/node-qt-rss.js";
-  const std::string data_path = cpplocate::locatePath(js_file);
+  const std::string data_path = cpplocate::locatePath(js_file, "", NULL);
   if (data_path.empty()) {
     qWarning() << "Could not find data path.";
     return 1;


### PR DESCRIPTION
Hi,

I've got some errors when compiling the examples. Further investigation showed that [this](https://github.com/cginternals/cpplocate/blob/6cae379d94c03f211b429e209c49ebf716b0ce18/source/cpplocate/include/cpplocate/cpplocate.h) commit changed the signature of locatePath.
The changes I'm submitting fixed the compiling errors.

Thank you!

